### PR TITLE
Do not show the install prompt if launched from TWA

### DIFF
--- a/src/ServiceWorkerLifecycle.tsx
+++ b/src/ServiceWorkerLifecycle.tsx
@@ -20,12 +20,8 @@ const actionButtonStyles = {
 
 const ServiceWorkerLifecycle = () => {
   const history = useHistory();
-  const {
-    active,
-    freshlyInstalled,
-    updateAvailable,
-    registration,
-  } = useContext(ServiceWorkerContext);
+  const { active, freshlyInstalled, updateAvailable, registration } =
+    useContext(ServiceWorkerContext);
 
   const {
     installLastDismissed,
@@ -40,6 +36,10 @@ const ServiceWorkerLifecycle = () => {
   const shouldShowFreshInstallNoti = async () => {
     // debugging
     // return true;
+
+    const windowUrl = window.location.search;
+    const params = new URLSearchParams(windowUrl);
+    if (params.get("utm_source") === "android_twa") return false;
 
     // freshly installed, unconditionally show!
     if (freshlyInstalled) return true;


### PR DESCRIPTION
Apparently the query string is the best place to check if the website has been launched in a TWA https://developer.chrome.com/docs/android/trusted-web-activity/query-parameters/